### PR TITLE
Allow defining new spells in `erweiterungen.csv`

### DIFF
--- a/HeldenSoftwareZauber.iml
+++ b/HeldenSoftwareZauber.iml
@@ -31,5 +31,6 @@
     <orderEntry type="library" name="Maven: asm:asm-commons:3.0" level="project" />
     <orderEntry type="library" name="Maven: asm:asm-tree:3.0" level="project" />
     <orderEntry type="library" name="Maven: asm:asm:3.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-csv:1.5" level="project" />
   </component>
 </module>

--- a/README.md
+++ b/README.md
@@ -210,6 +210,13 @@ Da viele Tabellenkalkulationen den Export nach CSV ermöglichen und dies für vi
 Die Konfiguration ist wie bei json zu handhaben:
 Die `erweiterungen.csv` Datei, kommt ins gleiche Verzeichnis wie eure `helden.zip.hld`, als `C:\Benutzer\XXX\helden\erweiterungen.csv` unter Windows bzw. `~/helden/erweiterungen.csv` unter Linux.
 
+Die folgende Tabelle veranschaulicht das Format:
+
+```
+Name,Kategorie,Merkmale,Probe,Mods/MR,Verbreitung,Settings
+Mein Zauber,D,Antimagie,MU/KL/CH,,Mag3,Aventurien
+
+```
 
 
 Entwickler

--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ Die komplette Beispiel-Datei gibt's hier: [examples.json](src/main/resources/exa
 ```
 
 
+### CSV
+
+Da viele Tabellenkalkulationen den Export nach CSV ermöglichen und dies für viele Anwender dies einfacher zu handhaben ist, besteht die Option neue Zauber auch über eine `erweiterungen.csv`-Datei zu importieren.
+Die Konfiguration ist wie bei json zu handhaben:
+Die `erweiterungen.csv` Datei, kommt ins gleiche Verzeichnis wie eure `helden.zip.hld`, als `C:\Benutzer\XXX\helden\erweiterungen.csv` unter Windows bzw. `~/helden/erweiterungen.csv` unter Linux.
+
+
 
 Entwickler
 ----------
@@ -236,6 +243,7 @@ Dieses Plugin basiert auf verschiedenen anderen Projekten:
 - [OpenPojo](https://github.com/oshoukry/openpojo), [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 - IntelliJ Forms_rt by [Jetbrains](http://www.jetbrains.com/), [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 - [ASM Commons](http://asm.ow2.org/), [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+- [Apache CSV](https://commons.apache.org/proper/commons-csv/), [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0) 
  
  
  

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ Das Plugin nutzt [Maven](https://maven.apache.org/) für seinen Build-Prozess.
 
 Bevor das Projekt compiliert werden kann, muss ein Ordner `heldensoftware` 
  im Hauptverzeichnis angelegt werden, und die `helden.jar` hineinkopiert werden. 
- Alternativ funktioniert auch ein Linux-Symlink ins Installationsverzeichnis (namens `heldensoftware`). 
+ Alternativ funktioniert auch ein Linux-Symlink ins Installationsverzeichnis (namens `heldensoftware`):
+ `ln -s <pfad zu helden.jar> heldensoftware`
  
  
  

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,13 @@
             <version>3.0</version>
         </dependency>
 
+        <!-- Make parsing CSV documents easy -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.5</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
+        <helden.version>5.5.2</helden.version>
     </properties>
 
 
@@ -39,9 +40,8 @@
                         </manifest>
                         <manifestEntries>
                             <!-- HeldenPluginClass: heldenbildPlugin.HeldenbildPlugin.class -->
-                            <HeldenDatenPluginClass>de.mb.heldensoftware.customentries.CustomEntryLoaderPlugin.class
-                            </HeldenDatenPluginClass>
-                            <Class-Path>. helden.jar helden5.jar</Class-Path>
+                            <HeldenDatenPluginClass>de.mb.heldensoftware.customentries.CustomEntryLoaderPlugin.class</HeldenDatenPluginClass>
+                            <Class-Path>. helden.jar helden5.jar helden-${helden.version}.jar</Class-Path>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -134,6 +134,26 @@
                     <failOnError>true</failOnError>
                 </configuration>
             </plugin>
+
+            <!-- Copy helden.jar to target directory to make development easier -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <includeScope>system</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -141,7 +161,7 @@
         <dependency>
             <groupId>de.helden_software</groupId>
             <artifactId>helden</artifactId>
-            <version>5.5.2</version>
+            <version>${helden.version}</version>
             <scope>system</scope>
             <!-- You can use a symlink to the installation directory, if you're on linux, and want life to be easy! -->
             <systemPath>${project.basedir}/heldensoftware/helden.jar</systemPath>

--- a/src/main/java/de/mb/heldensoftware/customentries/CsvConverter.java
+++ b/src/main/java/de/mb/heldensoftware/customentries/CsvConverter.java
@@ -1,0 +1,119 @@
+package de.mb.heldensoftware.customentries;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CsvConverter {
+
+    public interface Columns {
+        String Name = "name";
+        String Kategorie = "Kategorie";
+        String Merkmale = "Merkmale";
+        String Probe = "Probe";
+        String MODS_MR = "Mods/MR";
+        String Verbreitung = "Verbreitung";
+        String Settings = "Settings";
+    }
+
+    public InputStream convertToJson(Path p) throws IOException {
+        final String[] columns = new String[] {
+                Columns.Name, Columns.Kategorie,
+                Columns.Merkmale, Columns.Probe,
+                Columns.MODS_MR, Columns.Verbreitung,
+                Columns.Settings
+        };
+        final CSVFormat csvFormat = CSVFormat.DEFAULT
+                .withHeader(columns)
+                .withSkipHeaderRecord();
+
+        // TODO MVR close reader/parser
+        final FileReader fileReader = new FileReader(p.toFile());
+        final CSVParser parser = new CSVParser(fileReader, csvFormat);
+        final Map<String, Integer> headerMap = parser.getHeaderMap();
+
+        // Verify Existence of columns
+        for (String headerName : columns) {
+            if (!headerMap.containsKey(headerName)) {
+                throw new IllegalStateException("Es wurde keine Spalte mit der Bezeichnung '" + headerName + "' gefunden.");
+            }
+        }
+
+        // Now try to convert
+        final List<CSVRecord> records = parser.getRecords();
+        final JSONArray spells = new JSONArray();
+        for (CSVRecord eachRecord : records) {
+            final JSONObject spell = new JSONObject();
+            spell.put("name", "A " + eachRecord.get(Columns.Name));
+            spell.put("kategorie", eachRecord.get(Columns.Kategorie));
+            spell.put("merkmale", parseList(eachRecord.get(Columns.Merkmale), ","));
+            spell.put("probe", eachRecord.get(Columns.Probe));
+            spell.put("mod", eachRecord.get(Columns.MODS_MR));
+            spell.put("settings", parseList(eachRecord.get(Columns.Settings), ","));
+            spell.put("verbreitung", parseVerbreitung(eachRecord.get(Columns.Verbreitung), ","));
+            spells.add(spell);
+        }
+
+        final JSONObject root = new JSONObject();
+        root.put("zauber", spells);
+        return new ByteArrayInputStream(root.toJSONString().getBytes());
+
+    }
+
+    private static List<String> parseList(String input, String delimiter) {
+        final String[] split = input.split(delimiter);
+        final List<String> items = new ArrayList<>();
+        for (String eachItem : split) {
+            // Some users enter "x, y, z", which results in some values containing a space
+            // therefore we trim each value just to be sure
+            final String trimmedItem = eachItem.trim();
+            if (!trimmedItem.isEmpty()) {
+                items.add(trimmedItem);
+            }
+        }
+        return items;
+    }
+
+    private static JSONObject parseVerbreitung(String input, String delimiter) {
+        final JSONObject verbreitungObj = new JSONObject();
+        final List<String> verbreitungen = parseList(input, delimiter);
+        for (String eachVerbreitung : verbreitungen) {
+
+            // Determine numeric value
+            int index = -1;
+            for (int i=0; i<eachVerbreitung.length(); i++) {
+                if (Character.isDigit(eachVerbreitung.charAt(i))) {
+                    index = i;
+                    break;
+                }
+            }
+
+            // if not found, bail
+            if (index == -1) {
+                throw new IllegalArgumentException("Verbreitung '" + eachVerbreitung + "' ist nicht gültig.");
+            }
+
+            // Otherwise separate values
+            final String type = eachVerbreitung.substring(0, index);
+            final String numString = eachVerbreitung.substring(index);
+            try {
+                verbreitungObj.put(type, Integer.parseInt(numString));
+            } catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("Verbreitung '" + eachVerbreitung + "' enthält keine gültige Zahl. " +
+                        "Erwartet wurde eine Zahl zwischen 1 und 7, erhaltener Wert war: " + numString);
+            }
+        }
+        return verbreitungObj;
+    }
+}

--- a/src/test/java/de/mb/heldensoftware/customentries/CustomEntryLoaderTest.java
+++ b/src/test/java/de/mb/heldensoftware/customentries/CustomEntryLoaderTest.java
@@ -1,0 +1,21 @@
+package de.mb.heldensoftware.customentries;
+
+import org.json.simple.parser.ParseException;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+public class CustomEntryLoaderTest {
+
+    @Test
+    public void testExampleFile() {
+        try (Reader r = new InputStreamReader(getClass().getResourceAsStream("/examples/examples.json"))){
+            new CustomEntryLoader().loadCustomEntries(r);
+        } catch (IOException | ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
For most users it is easier to define spells in a spreadsheet application, such as libre or open office, which also allow exporting to CSV. This enhancement allows to have a `erweiterungen.csv` in addition to a `erweiterungen.json` thus allowing importing from csv.

At the moment each spell from `erweiterungen.csv` is prefixed with an `A` so it can overwrite existing spells and new spells are always at the top of the list.

If you have any questions or need me to change things, just let me know.